### PR TITLE
maintenance: replace lilliput with native go

### DIFF
--- a/main.go
+++ b/main.go
@@ -206,6 +206,7 @@ func OpenImage(p string) (image.Image, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer f.Close()
 	ext := strings.ToLower(filepath.Ext(p))
 	var fn func(io.Reader) (image.Image, error)
 	switch ext {


### PR DESCRIPTION
I did this because for some reason it was not handling certain images and I'm not about to fix a third party library.