### PR TITLE
Allow simple pattern matching on host permission

### DIFF
--- a/cmd/delivery/Dockerfile
+++ b/cmd/delivery/Dockerfile
@@ -4,7 +4,7 @@ ENV PROJECTID=""
 ENV BUCKET="minicat"
 ENV HOST=""
 ENV ALLOW="www.monstercat.com, player.monstercat.app, cdn.monstercat.com, labelmanager.app, api.labelmanager.app, www.monstercat.dev"
-RUN apk add build-base
+RUN apk add build-base git
 WORKDIR src/github.com/monstercat/asset-delivery
 ADD . .
 RUN go get .

--- a/cmd/delivery/server.go
+++ b/cmd/delivery/server.go
@@ -26,11 +26,31 @@ func (s *Server) HostPermitted(host string) bool {
 		return true
 	}
 	for _, x := range s.PermittedHosts {
-		if strings.TrimSpace(x) == host {
+		if testHostWithPattern(strings.TrimSpace(x), host) {
 			return true
 		}
 	}
 	return false
+}
+
+// testHostWithPattern will test the hosts, allowing for a * pattern (separated by .). Note that the host should still
+// contain the same # of parts. For example, *.monstercat.com will not match with beta.app.monstercat.com.
+func testHostWithPattern(pattern, host string) bool {
+	patternParts := strings.Split(pattern, ".")
+	hostParts := strings.Split(host, ".")
+	if len(hostParts) != len(patternParts) {
+		return false
+	}
+	for i, p := range patternParts {
+		curr := hostParts[i]
+		if p == "*" {
+			continue
+		}
+		if curr != p {
+			return false
+		}
+	}
+	return true
 }
 
 // TODO: generate a request id that can be passed along for all requests.

--- a/cmd/delivery/server_test.go
+++ b/cmd/delivery/server_test.go
@@ -1,0 +1,15 @@
+package main
+
+import "testing"
+
+func TestTestHostWithPattern(t *testing.T) {
+	host := "abcdef1235939023.some-host.run.app"
+	pattern := "*.some-host.run.app"
+	if !testHostWithPattern(pattern, host) {
+		t.Error("Host should match pattern but it does not.")
+	}
+	host = "some-host.some-host.notrun.app"
+	if testHostWithPattern(pattern, host) {
+		t.Error("Host should not match pattern but it does.")
+	}
+}


### PR DESCRIPTION
Allows * to replace a segment of a host. This is to allow for dynamic subdomains.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202185143390354