### PR TITLE
Fix resize failure on extensionless source URLs

### DIFF
--- a/resize.go
+++ b/resize.go
@@ -24,7 +24,7 @@ func Resize(fs FileSystem, opts ResizeOptions) error {
 	if err != nil {
 		return &ParamError{Param: "url", Detail: fmt.Sprintf("Could not get image: %s", opts.Location), RootError: err}
 	}
-	img, err := ReaderToImage(bytes.NewReader(buf), opts.Location)
+	img, format, err := ReaderToImage(bytes.NewReader(buf), opts.Location)
 	if err != nil {
 		return &ParamError{Param: "url", Detail: "Could not read URL as an image.", RootError: err}
 	}
@@ -32,7 +32,7 @@ func Resize(fs FileSystem, opts ResizeOptions) error {
 	if err != nil {
 		return &SystemError{Detail: "Could not resize the provided image.", RootError: err}
 	}
-	bits, err := ImageToBytes(img, opts.DesiredEncoding(), 80)
+	bits, err := ImageToBytes(img, resolveEncoding(opts.DesiredEncoding(), format), 80)
 	if err != nil {
 		return &SystemError{Detail: "An error occurred.", RootError: err}
 	}
@@ -87,31 +87,64 @@ func DefaultImageDecode(r io.Reader) (image.Image, error) {
 	return img, nil
 }
 
-// Reader to image will try to read the image
-func ReaderToImage(r io.ReadSeeker, hint string) (image.Image, error) {
+// ReaderToImage decodes r as an image, using hint's extension to pick
+// the decoder when it names a supported format and falling back to
+// image.Decode otherwise. The returned format is the auto-detected
+// format name ("jpeg", "png", "webp", ...) when the fallback path is
+// taken, or the format implied by the hint when the typed decoder
+// succeeds. Callers can use it to choose an output encoding when the
+// hint URL has no extension.
+func ReaderToImage(r io.ReadSeeker, hint string) (image.Image, string, error) {
 	ext := strings.ToLower(filepath.Ext(hint))
 	var fn func(io.Reader) (image.Image, error)
+	var formatHint string
 	switch ext {
 	case ".jpeg", ".jfif", ".jpg":
 		fn = jpeg.Decode
+		formatHint = "jpeg"
 	case ".png":
 		fn = png.Decode
+		formatHint = "png"
 	case ".webp":
 		fn = webp.Decode
-	default:
-		fn = DefaultImageDecode
+		formatHint = "webp"
 	}
 
-	img, triedError := fn(r)
-	if triedError != nil {
-		r.Seek(0, io.SeekStart)
-		img, err := DefaultImageDecode(r)
-		if err != nil {
-			return nil, triedError
+	if fn != nil {
+		if img, err := fn(r); err == nil {
+			return img, formatHint, nil
 		}
-		return img, nil
+		if _, err := r.Seek(0, io.SeekStart); err != nil {
+			return nil, "", err
+		}
 	}
-	return img, nil
+
+	img, format, err := image.Decode(r)
+	if err != nil {
+		return nil, "", &ParamError{
+			Param:     "url",
+			RootError: err,
+			Detail:    "Unsupported image format.",
+		}
+	}
+	return img, format, nil
+}
+
+// resolveEncoding picks the output extension for ImageToBytes. It
+// prefers the caller-supplied hint when it names a supported format
+// (covering the explicit `encoding=` query param and URLs with usable
+// extensions); otherwise it falls back to the format detected during
+// decode. Both inputs being empty/unknown returns the hint unchanged,
+// which lets ImageToBytes surface ErrFileNotHandled as before.
+func resolveEncoding(hint, detected string) string {
+	switch strings.ToLower(hint) {
+	case ".jpeg", ".jfif", ".jpg", ".png", ".webp":
+		return hint
+	}
+	if detected != "" {
+		return "." + detected
+	}
+	return hint
 }
 
 func ImageToBytes(i image.Image, hint string, quality int) (*bytes.Buffer, error) {

--- a/resize_test.go
+++ b/resize_test.go
@@ -14,26 +14,66 @@ const (
 
 func TestReaderToImage(t *testing.T) {
 	cases := []struct {
-		Base64 string
-		Hint   string
+		Name           string
+		Base64         string
+		Hint           string
+		ExpectedFormat string
 	}{
-		{PngFileB64, "a.png"},
-		{PngFileB64, "a.webp"},
-		{PngFileB64, "a.jpeg"},
-		{WebPFileB64, "a.webp"},
-		{WebPFileB64, "a.png"},
-		{JpegFileB64, "a.jpeg"},
+		{"PNG with .png hint", PngFileB64, "a.png", "png"},
+		{"PNG with mismatched .webp hint", PngFileB64, "a.webp", "png"},
+		{"PNG with mismatched .jpeg hint", PngFileB64, "a.jpeg", "png"},
+		{"WebP with .webp hint", WebPFileB64, "a.webp", "webp"},
+		{"WebP with mismatched .png hint", WebPFileB64, "a.png", "webp"},
+		{"JPEG with .jpeg hint", JpegFileB64, "a.jpeg", "jpeg"},
+		// Regression: extensionless URLs (e.g., /api/artist/{uuid}/cover)
+		// must still decode and report the detected format so the caller
+		// can pick an output encoding.
+		{"PNG with extensionless hint", PngFileB64, "/api/artist/uuid/cover", "png"},
+		{"WebP with extensionless hint", WebPFileB64, "/api/artist/uuid/cover", "webp"},
+		{"JPEG with extensionless hint", JpegFileB64, "/api/artist/uuid/cover", "jpeg"},
 	}
 
 	for _, c := range cases {
-		b, err := base64.StdEncoding.DecodeString(c.Base64)
-		if err != nil {
-			t.Fatal(err)
-		}
+		t.Run(c.Name, func(t *testing.T) {
+			b, err := base64.StdEncoding.DecodeString(c.Base64)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		_, err = ReaderToImage(bytes.NewReader(b), c.Hint)
-		if err != nil {
-			t.Fatal(err)
-		}
+			img, format, err := ReaderToImage(bytes.NewReader(b), c.Hint)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if img == nil {
+				t.Fatal("expected decoded image, got nil")
+			}
+			if format != c.ExpectedFormat {
+				t.Fatalf("expected detected format %q, got %q", c.ExpectedFormat, format)
+			}
+		})
+	}
+}
+
+func TestResolveEncoding(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Hint     string
+		Detected string
+		Want     string
+	}{
+		{"explicit webp hint wins", ".webp", "jpeg", ".webp"},
+		{"jpg hint normalized through case", ".JPG", "png", ".JPG"},
+		{"empty hint falls back to detected", "", "png", ".png"},
+		{"unknown hint falls back to detected", ".tiff", "webp", ".webp"},
+		{"both empty stays empty (caller surfaces ErrFileNotHandled)", "", "", ""},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			got := resolveEncoding(c.Hint, c.Detected)
+			if got != c.Want {
+				t.Fatalf("resolveEncoding(%q, %q) = %q; want %q", c.Hint, c.Detected, got, c.Want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the `file type not handled` error reported on extensionless source URLs (e.g. `https://canary-candidate.soundscout.com/api/artist/{uuid}/cover`).

## Root cause

`Resize()` passed `opts.DesiredEncoding()` to `ImageToBytes`. For an extensionless URL with no `encoding=` query param, `DesiredEncoding()` returns `""`, and `ImageToBytes`'s `switch` falls through to `default: err = ErrFileNotHandled`.

`ReaderToImage` already recovered from a bad/missing hint by falling back to `image.Decode`, but it threw away the auto-detected format. `ImageToBytes` had no fallback at all.

## Fix

- `ReaderToImage` now returns `(image.Image, string, error)`. The string is the detected format ("jpeg", "png", "webp", ...) — derived from the typed decoder when the hint matches, or from `image.Decode`'s second return value when we fall back.
- New `resolveEncoding(hint, detected)` helper picks the output extension: hint wins when it names a supported format; detected wins when the hint is empty or unknown; if both are empty/unknown the hint is returned unchanged so callers still see `ErrFileNotHandled`.
- `Resize()` threads the detected format through `resolveEncoding` into `ImageToBytes`.

`ObjectKey()` still uses `DesiredEncoding()` unchanged, so the publish side (asset-delivery) and the consume side (resize worker / GCF) continue to agree on the GCS cache key.

## Test plan

- [x] New regression cases in `TestReaderToImage` for PNG/WebP/JPEG with hint = `/api/artist/uuid/cover` — each decodes and reports the correct format.
- [x] New `TestResolveEncoding` covering: explicit hint wins, case-insensitive hint match, empty hint → detected, unknown hint → detected, both empty → unchanged.
- [x] `go test ./...` green.

## Notes

Independent of #16 (the GCF → Cloud Run migration). This fix also lands behavior into the new resize service since it's all in the shared `Resize()` path.
