### PR TITLE
Fix asset-resize first-time deploy

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -82,6 +82,10 @@ steps:
     waitFor:
       - Build Resize
 
+  # --no-traffic is omitted: gcloud rejects it on first-time service
+  # creation (no existing revision to keep serving). Subsequent deploys
+  # update this same service in place at 100% traffic. Add --no-traffic
+  # back once staged rollouts are wanted.
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk
     entrypoint: gcloud
     args:
@@ -91,7 +95,8 @@ steps:
       - '--platform=$_PLATFORM'
       - '--region=$_DEPLOY_REGION'
       - '--image=$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/$_RESIZE_SERVICE_NAME:$COMMIT_SHA'
-      - '--no-traffic'
+      - '--no-allow-unauthenticated'
+      - '--quiet'
     id: Deploy Resize
     waitFor:
       - Push Resize


### PR DESCRIPTION
## Summary

The post-merge build for #16 failed at step `Deploy Resize`:

```
ERROR: (gcloud.run.deploy) --no-traffic not supported when creating a new service.
```

`--no-traffic` is invalid on first-time Cloud Run service creation (no existing revision to keep serving traffic). Removed it from the resize deploy step; the same service will be updated in place on subsequent deploys at 100% traffic, matching how `asset-delivery` already behaves. Re-add `--no-traffic` if/when staged rollouts are wanted.

Also added explicit `--no-allow-unauthenticated` (kills the interactive prompt that surfaced in the failing build log: `Allow unauthenticated invocations to [asset-resize] (y/N)?`) and `--quiet` (suppresses any further gcloud prompts in non-interactive mode).

## Test plan

- [ ] Merge → Cloud Build runs end-to-end on `main` → `asset-resize` Cloud Run service is created in `northamerica-northeast1` with authentication required.
